### PR TITLE
Allow returning binary data

### DIFF
--- a/brubeck/mongrel2.py
+++ b/brubeck/mongrel2.py
@@ -192,7 +192,7 @@ class Mongrel2Connection(object):
         internally.
         """
         header = "%s %d:%s," % (uuid, len(str(conn_id)), str(conn_id))
-        self.out_sock.send_unicode(header + ' ' + msg)        
+        self.out_sock.send(header + ' ' + to_bytes(msg))
 
     def reply(self, req, msg):
         """Does a reply based on the given Request object and message.


### PR DESCRIPTION
The Mongrel2Connection does not allow sending binary data because it uses pyzmq's send_unicode method. 

This commit uses the to_bytes to convert them to strings and sends them via pyzmq send(). This is essentially the same as pyzmq does, but also allows returning binary strings. 
