### PR TITLE
Allow passing of arbitrary arguments to Jinja2 at initialization

### DIFF
--- a/brubeck/templating.py
+++ b/brubeck/templating.py
@@ -34,7 +34,7 @@ class MakoRendering(object):
 ### Jinja2
 ###
 
-def load_jinja2_env(template_dir):
+def load_jinja2_env(template_dir, *args, **kwargs):
     """Returns a function that loads a jinja template environment. Uses a
     closure to provide a namespace around module loading without loading
     anything until the caller is ready.
@@ -42,7 +42,7 @@ def load_jinja2_env(template_dir):
     def loader():
         from jinja2 import Environment, FileSystemLoader
         if template_dir is not None:
-            return Environment(loader=FileSystemLoader(template_dir or '.'))
+            return Environment(loader=FileSystemLoader(template_dir or '.'), *args, **kwargs)
         else:
             return None
     return loader


### PR DESCRIPTION
My use case for this was needing the ability to create a routine to finalize output for Jinja templating, as per the Jinja2 docs (http://jinja.pocoo.org/docs/api/#high-level-api).  However allowing arbitrary arguments to be passed to Jinja2 environment creation allows the user more flexibility with respect to templating.  I haven't extended this to the other template code because I'm only using Jinja2 at this point, although I don't see why this couldn't easily be done there as well.
