### PR TITLE
Support 403 status code explicitly and handle unknown ones gracefully

### DIFF
--- a/brubeck/request_handling.py
+++ b/brubeck/request_handling.py
@@ -245,7 +245,7 @@ class MessageHandler(object):
         status msg to the the relevant msg as defined in _response_codes.
         """
         if status_msg is None:
-            status_msg = self._response_codes[status_code]
+            status_msg = self._response_codes.get(status_code, str(status_code))
         if extra_txt:
             status_msg = '%s - %s' % (status_msg, extra_txt)
         self.add_to_payload(self._STATUS_CODE, status_code)
@@ -341,6 +341,7 @@ class WebMessageHandler(MessageHandler):
         200: 'OK',
         400: 'Bad request',
         401: 'Authentication failed',
+        403: 'Forbidden',
         404: 'Not found',
         405: 'Method not allowed',
         500: 'Server error',


### PR DESCRIPTION
At the moment if you try to return a response with a status code that hasn't been explicitly defined in WebMessageHandler._response_codes it will fail, unless you also provide the status message. It seems more helpful to just use the status code itself as the message.

I discovered this while trying to return a 403 Forbidden error, so I've added that one explicitly.
