### PR TITLE
Added support for kwargs in mako template loader function

### DIFF
--- a/brubeck/templating.py
+++ b/brubeck/templating.py
@@ -4,13 +4,13 @@ from request_handling import WebMessageHandler
 ### Mako templates
 ###
 
-def load_mako_env(template_dir, *vals):
+def load_mako_env(template_dir, *vals, **kwargs):
     """Returns a function which loads a Mako templates environment.
     """
     def loader():
         from mako.lookup import TemplateLookup
         if template_dir is not None:
-            return TemplateLookup(directories=[template_dir or '.'], *vals)
+            return TemplateLookup(directories=[template_dir or '.'], *vals, **kwargs)
         else:
             return None
     return loader


### PR DESCRIPTION
Current load_mako_env does not support passing kwargs which are required for initializing TemplateLookup for Mako. Ex. input_encoding, output_encoding, default_filters etc.
