### PR TITLE
content-type in longpolling demo

### DIFF
--- a/demos/demo_longpolling.py
+++ b/demos/demo_longpolling.py
@@ -19,7 +19,8 @@ class DemoHandler(WebMessageHandler, Jinja2Rendering):
 class FeedHandler(WebMessageHandler):
     def get(self):
         eventlet.sleep(5) # simple way to demo long polling :)
-        self.set_body('The current time is: %s' % datetime.datetime.now())
+        self.set_body('The current time is: %s' % datetime.datetime.now(),
+                      headers={'Content-Type': 'text/plain'})
         return self.render()
 
 


### PR DESCRIPTION
Some browsers (firefox 3.6) apparently don't like ajax response with no content-type
... you get "xml document" gobbledygook instead of the current time displayed in page
