### PR TITLE
Adds a note regarding the libevent dependency of gevent

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -78,6 +78,7 @@ To install `gevent` support:
 
     $ pip install -I -r ./envs/gevent.reqs
 
+Note that gevent requires `libevent`, which should be available on the package-manager of your choice.
 
 ### Brubeck Itself
 


### PR DESCRIPTION
While the dependency is mentioned on the design page, it doesn't get
mentioned again during the installation instructions. This adds a
little reminder.
