### PR TITLE
pystache 0.5.0 support, much cleaner, but breaks compatibility with older pystache

### DIFF
--- a/brubeck/templating.py
+++ b/brubeck/templating.py
@@ -127,25 +127,11 @@ def load_mustache_env(template_dir, *args, **kwargs):
     anything until the caller is ready.
     """
     def loader():
-        return MustacheEnvironment(template_dir)
-
-    return loader
-
-class MustacheEnvironment(object):
-    """
-    An environment to render mustache templates.
-    """
-    def __init__(self, template_dirs):
         import pystache
 
-        self.pystache = pystache
-        self.template_dirs = template_dirs
+        return pystache.Renderer(search_dirs=[template_dir])
 
-    def render(self, template_file, context):
-        view = self.pystache.View(context=context)
-        view.template_name = template_file
-        view.template_path = self.template_dirs
-        return view.render()
+    return loader
 
 
 class MustacheRendering(WebMessageHandler):
@@ -163,7 +149,9 @@ class MustacheRendering(WebMessageHandler):
         Renders payload as a mustache template
         """
         mustache_env = self.application.template_env
-        body = mustache_env.render(template_file, context or {})
+
+        template = mustache_env.load_template(template_file)
+        body = mustache_env.render(template, context or {})
 
         self.set_body(body, status_code=_status_code)
         return self.render()

--- a/demos/templates/mustache/nested_partial.mustache
+++ b/demos/templates/mustache/nested_partial.mustache
@@ -1,0 +1,1 @@
+<p>And take five more.</p>

--- a/demos/templates/mustache/success.mustache
+++ b/demos/templates/mustache/success.mustache
@@ -3,6 +3,6 @@
   <title>Successful Mustache Template Render</title>
 </head>
 <body>
-  <p>Take five, {{name}}!</p>
+  {{> take_five}}
 </body>
 </html>

--- a/demos/templates/mustache/take_five.mustache
+++ b/demos/templates/mustache/take_five.mustache
@@ -1,0 +1,2 @@
+<p>Take five, {{name}}!</p>
+{{> nested_partial}}


### PR DESCRIPTION
They just released a new, much cleaner version of pystache that breaks backwards compatibility.  The mustache renderer in Brubeck thus was not working with the pystache available on PyPI.  This fixes that.

I don't know how you feel about breaking Brubeck's Mustache support for pre-0.5.0 pystache;  the new API is much cleaner and should be stable moving forward.  I can rewrite this to handle older versions, but the old API was messy.  I was glad to be rid of the code that dealt with it.

I also improved the test to show off nested partial loading, which was something that was broken externally with pre-0.5.0 pystache.
