### PR TITLE
pystache 0.4.1 has no `Renderer` class, 0.5.1 does.

### DIFF
--- a/envs/brubeck.reqs
+++ b/envs/brubeck.reqs
@@ -2,7 +2,7 @@ Cython==0.15.1
 Jinja2==2.6
 #Mako==0.7.0
 #tornado==2.2
-#pystache==0.4.1
+#pystache==0.5.1
 dictshield==0.4.3
 py-bcrypt==0.2
 pymongo==2.1.1


### PR DESCRIPTION
`load_mustache_env` in `templating.py` uses `pystache.Renderer` which doesn't exist in 0.4.1.
