### PR TITLE
add pub sub logging

### DIFF
--- a/demos/m2reader.py
+++ b/demos/m2reader.py
@@ -3,8 +3,9 @@
 import zmq
 
 ctx = zmq.Context()
-s = ctx.socket(zmq.PULL)
-s.connect("ipc://127.0.0.1:9999")
+s = ctx.socket(zmq.SUB)
+s.connect("tcp://127.0.0.1:9955")
+s.setsockopt(zmq.SUBSCRIBE, "")
 
 while True:
     msg = s.recv()


### PR DESCRIPTION
within the app I would pass the `logger` object, which is simply a zeromq PUB socket.

```
ctx = zmq.Context()
logging_sock = ctx.socket(zmq.PUB)
logging_sock.bind("tcp://127.0.0.1:9955")
config = {
    'msg_conn': Mongrel2Connection('tcp://127.0.0.1:9999', 'tcp://127.0.0.1:9998', logger=logging_sock),
    'handler_tuples': [(r'^/chatsocket', WebsocketHandler),
                   (r'^/', DisplayChatPage)],

}
app = Brubeck(**config)
app.run()
```

`m2reader.py` looks like this:

```
import zmq

ctx = zmq.Context()
s = ctx.socket(zmq.SUB)
s.connect("tcp://127.0.0.1:9955")
s.setsockopt(zmq.SUBSCRIBE, "")

while True:
    msg = s.recv()
    print msg
```

Considering that a WSGI server wouldn't normally have a need to run zeromq, I don't know how you would want to handle logging with `WSGIConnection`.
