### PR TITLE
Redisqueryset

### DIFF
--- a/brubeck/queryset.py
+++ b/brubeck/queryset.py
@@ -1,9 +1,11 @@
 from request_handling import FourOhFourException
 from itertools import imap
 import zlib
-import redis
 import ujson as json
-
+try:
+    import redis
+except ImportError:
+    pass
 
 class AbstractQueryset(object):
     """The design of the `AbstractQueryset` attempts to map RESTful calls


### PR DESCRIPTION
Fix redis import error for those that don't have redis-py installed. Also, this removes useless list comprehensions.
