### PR TITLE
Customization point when rendering error output

### DIFF
--- a/brubeck/auth.py
+++ b/brubeck/auth.py
@@ -61,7 +61,7 @@ def authenticated(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         if not self.current_user:
-            return self.render_error(self._AUTH_FAILURE)
+            return self.render_error(self._AUTH_FAILURE, self.auth_error)
         return method(self, *args, **kwargs)
     return wrapper
 
@@ -127,3 +127,8 @@ class UserHandlingMixin(object):
         """Override to determine the current user
         """
         return None
+
+    def auth_error(self):
+        """Override with actions to perform before rendering the error output.
+        """
+        pass

--- a/brubeck/request_handling.py
+++ b/brubeck/request_handling.py
@@ -278,10 +278,13 @@ class MessageHandler(object):
         rendered = json.dumps(self._payload)
         return rendered
 
-    def render_error(self, status_code, **kwargs):
-        """Clears the payload before rendering the error status
+    def render_error(self, status_code, error_handler=None, **kwargs):
+        """Clears the payload before rendering the error status.
+        Takes a callable to perform customization before rendering the output.
         """
         self.clear_payload()
+        if error_handler:
+            error_handler()
         self._finished = True
         return self.render(status_code=status_code)
 


### PR DESCRIPTION
Add a parameter to `render_error` in MessageHandler that is a callable to allow
a customization point before rendering the output. This way callers can override
the headers, payload and/or status before the response is sent.

Implemented for decorator `@authenticated` to pass `auth_error` method from
UserHandlingMixin class when authentication fails.
