### PR TITLE
Tell Redis to do flushdb in TestRedisQueryset.setUp so that tests always...

### DIFF
--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -192,6 +192,7 @@ class TestRedisQueryset(unittest.TestCase):
     def setUp(self):
         import redis
         redis_connection = redis.StrictRedis(host='localhost', port=6379, db=0)
+        redis_connection.flushdb()
         self.queryset = RedisQueryset(db_conn=redis_connection)
 
     def seed_reads(self):


### PR DESCRIPTION
... start with a clean slate.

Without this, I get the following error on most test runs, because Redis will persist the state from previous runs.

```
marc@hyperion:~/dev/git-repos/brubeck
13:29:27 $ tox -e py27
_________________________________________________________________________________ [tox sdist] __________________________________________________________________________________
[TOX] ***creating sdist package
[TOX] /Users/marc/dev/git-repos/brubeck$ /Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python setup.py sdist --formats=zip --dist-dir .tox/dist >.tox/log/0.log
[TOX] ***copying new sdistfile to '/Users/marc/.tox/distshare/brubeck-0.4.0.zip'
______________________________________________________________________________ [tox testenv:py27] ______________________________________________________________________________
[TOX] ***reusing existing matching virtualenv py27
[TOX] ***upgrade-installing sdist
[TOX] /Users/marc/dev/git-repos/brubeck/.tox/py27/log$ ../bin/pip install --download-cache=/Users/marc/dev/git-repos/brubeck/.tox/_download -U --no-deps ../../dist/brubeck-0.4.0.zip >22.log
[TOX] /Users/marc/dev/git-repos/brubeck$ .tox/py27/bin/nosetests --exe -w tests
.........F.........................
======================================================================
FAIL: test__create_many (tests.test_queryset.TestRedisQueryset)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marc/dev/git-repos/brubeck/tests/test_queryset.py", line 229, in test__create_many
    self.assertEqual(self.queryset.MSG_CREATED, status)
AssertionError: 'Created' != 'Updated'

----------------------------------------------------------------------
Ran 35 tests in 0.064s

FAILED (failures=1)
[TOX] ERROR: InvocationError: '.tox/py27/bin/nosetests --exe -w tests'
________________________________________________________________________________ [tox summary] _________________________________________________________________________________
[TOX] ERROR: py27: commands failed
```
