### PR TITLE
Test with fakeredis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 before_install:
   - sudo apt-get install libevent-dev
-  - pip install --use-mirrors gevent nose redis testtools
+  - pip install --use-mirrors gevent nose fakeredis==0.3.0 testtools
 
 install:
   - python setup.py install

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -190,8 +190,8 @@ class TestRedisQueryset(unittest.TestCase):
 
 
     def setUp(self):
-        import redis
-        redis_connection = redis.StrictRedis(host='localhost', port=6379, db=0)
+        from fakeredis import FakeRedis
+        redis_connection = FakeRedis()
         redis_connection.flushdb()
         self.queryset = RedisQueryset(db_conn=redis_connection)
 
@@ -202,16 +202,6 @@ class TestRedisQueryset(unittest.TestCase):
 
 
     def test__create_one(self):
-        # TODO: - fix test
-        # Test will fail, unless the value associated with 
-        # 'id': 'foo' is deleted. Normally, during this test an object with id='foo'
-        # exists- test may need to be fixed. If the object "foo" exists
-        # the first operation will return self.queryset.MSG_UPDATED instead
-        # of self.queryset.MSG_FAILED
-        import redis
-        redis_connection = redis.StrictRedis(host='localhost', port=6379, db=0)
-        redis_connection.delete('id')
-        
         shield = TestDoc(id="foo")
         status, return_shield = self.queryset.create_one(shield)
         self.assertEqual(self.queryset.MSG_CREATED, status)

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ commands = nosetests --exe -w tests
 deps =
     gevent
     nose
-    redis
+    fakeredis==0.3.0
     testtools


### PR DESCRIPTION
Here is one possible solution to the issues of running a Redis server for testing discussed in [#92](https://github.com/j2labs/brubeck/pull/92#issuecomment-10294378).

This uses a package called [fakeredis](https://github.com/jamesls/fakeredis) which mocks out Redis completely. The nice thing about this project is that the author has invested time in writing tests that verify that the behavior of fakeredis matches the behavior of a real Redis server, so the mock should be pretty faithful.

Using a mock is nice because it eliminates having to launch a Redis server (or risk inadvertently using an existing Redis server) to run the Brubeck tests.
