### PR TITLE
Add mock to list of deps in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ setenv = CFLAGS="-I/usr/local/include"
 commands = nosetests --exe -w tests
 deps =
     gevent
+    mock
     nose
     redis
     testtools


### PR DESCRIPTION
#95 added a dependency on `mock` so `tox` fails without this.
