### PR TITLE
Add support for CORS in WebMessageHandler

### DIFF
--- a/brubeck/request_handling.py
+++ b/brubeck/request_handling.py
@@ -486,8 +486,7 @@ class WebMessageHandler(MessageHandler):
 
     def cors_request(self):
         """Handle CORS request"""
-        request_headers = self.message.headers
-        origin = request_headers.get('Origin')
+        origin = self.message.headers.get('Origin')
         # ignore non-CORS requests
         if not origin:
             return


### PR DESCRIPTION
Allow easy support for [Cross-Origin Resource Sharing](http://www.w3.org/TR/cors/) requests by
simply returning a list of hosts on the `cors_allow_origin` method.
