### PR TITLE
Keep blank values on POST and PUT requests

### DIFF
--- a/brubeck/request.py
+++ b/brubeck/request.py
@@ -53,9 +53,7 @@ class Request(object):
             form_encoding = "application/x-www-form-urlencoded"
             if self.content_type.startswith(form_encoding):
                 arguments = urlparse.parse_qs(self.body, keep_blank_values=True)
-                for name, values in arguments.iteritems():
-                    if values:
-                        self.arguments.setdefault(name, []).extend(values)
+                self.arguments.update(arguments)
             # Not ready for this, but soon
             elif self.content_type.startswith("multipart/form-data"):
                 fields = self.content_type.split(";")


### PR DESCRIPTION
Changed this so there are no made assumptions about how the client
code will handle empty form fields. Also, moved all calls from cgi
to urlparse since its the new module for these things.
